### PR TITLE
「SOAP記入」を選択してもメニューバーの色が変わらない不具合を修正．

### DIFF
--- a/View/Elements/admin_menu.ctp
+++ b/View/Elements/admin_menu.ctp
@@ -18,7 +18,7 @@
 			$is_active = ($this->name=='Records') ? ' active' : '';
 			echo '<li class="'.$is_active.'">'.$this->Html->link(__('学習履歴'), array('controller' => 'records', 'action' => 'index')).'</li>';
 
-			$is_active = ($this->name=='SOAP') ? ' active' : '';
+			$is_active = ($this->name=='Soaps') ? ' active' : '';
 			echo '<li class="'.$is_active.'">'.$this->Html->link(__('SOAP記入'), array('controller' => 'soaps', 'action' => 'index')).'</li>';
 
 			if($loginedUser['role']=='admin')


### PR DESCRIPTION
画面上部のメニューバーで「SOAP記入」を選んでも，「SOAP記入」の箇所が暗くなっていませんでしたので，修正しました．