### PR TITLE
レイアウト修正＋コンテンツをもう一回受講するボタンを追加

### DIFF
--- a/View/ContentsQuestions/index.ctp
+++ b/View/ContentsQuestions/index.ctp
@@ -10,9 +10,11 @@
 	else
 	{
 		$course_url = array('controller' => 'contents', 'action' => 'index', $content['Course']['id']);
+		
 		$this->Html->addCrumb(__('コース一覧'), array('controller' => 'users_courses', 'action' => 'index'));
 	}
-	
+
+	$content_url = array('controller' => 'contents_questions', 'action' => 'index', $content['Content']['id']);
 	$this->Html->addCrumb($content['Course']['title'], $course_url);
 	$this->Html->addCrumb(h($content['Content']['title'])); // addCrumb 内でエスケープされない為、別途エスケープ
 	echo $this->Html->getCrumbs(' / ');
@@ -83,8 +85,15 @@
   <div class = "text-block">
   <object data="<?php echo h($text_url);?>" type="application/pdf"
 ></object>
-  </div>
-  <div class = "quiz-block">
+	</div>
+	<?php
+		if($is_record){
+			echo '<input type="button" value="戻る" class="btn btn-default btn-lg" onclick="location.href=\''.Router::url($course_url).'\'">';
+			echo '<input type="button" value="もう一回やる" class="btn btn-primary btn-lg" onclick="location.href=\''.Router::url($content_url).'\'">';
+		}
+	?>
+	<div class = "quiz-block">
+	
 	<?php echo $this->Form->create('ContentsQuestion'); ?>
 		<?php foreach ($contentsQuestions as $contentsQuestion){ ?>
 			<?php

--- a/View/Enquete/admin_index.ctp
+++ b/View/Enquete/admin_index.ctp
@@ -86,11 +86,11 @@ function downloadCSV()
 				<th nowrap><?php echo $this->Paginator->sort('Enquete.group_id', '担当講師'); ?></th>
 				<th nowrap><?php echo $this->Paginator->sort('User.period', '所属'); ?></th>
 				<th nowrap><?php echo $this->Paginator->sort('Enquete.today_impressions', '今日の感想'); ?></th>
-				<th nowrap><?php echo $this->Paginator->sort('Enquete.before_goal_cleared', '前回ゴールT/F'); ?></th>
-				<th nowrap><?php echo $this->Paginator->sort('Enquete.before_false_reason', '前回ゴールF理由'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('Enquete.before_goal_cleared', '前回T/F'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('Enquete.before_false_reason', '前回F理由'); ?></th>
 				<th nowrap><?php echo $this->Paginator->sort('Enquete.today_goal', '今日のゴール'); ?></th>
-				<th nowrap><?php echo $this->Paginator->sort('Enquete.today_goal_cleared', '今日のゴールT/F'); ?></th>
-				<th nowrap><?php echo $this->Paginator->sort('Enquete.today_false_reason', '今日のゴールF理由'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('Enquete.today_goal_cleared', '今日T/F'); ?></th>
+				<th nowrap><?php echo $this->Paginator->sort('Enquete.today_false_reason', '今日F理由'); ?></th>
 				<th nowrap><?php echo $this->Paginator->sort('Enquete.next_goal', '次回までゴール'); ?></th>
 			</tr>
 		</thead>

--- a/View/Layouts/default.ctp
+++ b/View/Layouts/default.ctp
@@ -33,9 +33,11 @@
 		echo $this->Html->css('common.css?20190401');
 
 		// 管理画面用CSS
-		if($is_admin_page)
+		if($is_admin_page){
 			echo $this->Html->css('admin.css?20190401');
-
+		}else{
+			echo $this->Html->css('user.css?20191008');
+		}
 		// カスタマイズ用CSS
 		echo $this->Html->css('custom.css?20190401');
 

--- a/webroot/css/admin.css
+++ b/webroot/css/admin.css
@@ -114,7 +114,7 @@
 {
 	display			: inline-block !important;
 	margin-right	: 10px !important;
-	widht			: 85%;
+	width			: 85%;
 }
 
 .admin-contents-edit .form-control-filename

--- a/webroot/css/user.css
+++ b/webroot/css/user.css
@@ -1,0 +1,61 @@
+@charset "utf-8";
+/*
+ * Ripple  Project
+ *
+ * @author        Enfu Guo
+ * @copyright     NPO Organization uec support
+ * @link          http://uecsupport.dip.jp/
+ * @license       http://www.gnu.org/licenses/gpl-3.0.en.html GPL License
+ */
+
+#container,
+.header,
+.footer
+{
+	min-width		: 768px;
+}
+
+.ib-horizontal
+{
+	min-width		: 768px;
+}
+
+.navbar-toggle
+{
+	display			: none;
+}
+
+.collapse
+{
+	display			: block;
+	border-color	: transparent;
+}
+
+.navbar-right
+{
+	float			: right;
+}
+
+.navbar-header
+{
+	float			: left;
+}
+
+.navbar-nav
+{
+	margin			: 0 -15px 0 0;
+}
+
+.navbar-nav>li>a
+{
+	padding-top		: 15px;
+	padding-bottom	: 15px;
+}
+
+@media (min-width: 768px)
+{
+	.container
+	{
+		width		: initial;
+	}
+}


### PR DESCRIPTION
レイアウト修正：
受講生側：
　ブラウザを小さくしても，メニューバーが消えないように修正
　採点後，「戻る」ボタンを上に移動．「もう一回やる」ボタンを追加
管理側：
　SOAP一覧のレイアウトを変更
